### PR TITLE
Fix animation stuck in overscroll in some cases

### DIFF
--- a/flinger/src/main/java/io/iamjosephmj/flinger/flings/FlingerFlingBehavior.kt
+++ b/flinger/src/main/java/io/iamjosephmj/flinger/flings/FlingerFlingBehavior.kt
@@ -50,12 +50,16 @@ class FlingerFlingBehavior(
                 initialValue = 0f,
                 initialVelocity = initialVelocity,
             ).animateDecay(flingDecay) {
-                val delta = value - lastValue
-                val consumed = scrollBy(delta)
-                lastValue = value
-                velocityLeft = this.velocity
-                // avoid rounding errors and stop if anything is unconsumed
-                if (abs(delta - consumed) > 0.5f) this.cancelAnimation()
+                try {
+                    val delta = value - lastValue
+                    val consumed = scrollBy(delta)
+                    lastValue = value
+                    velocityLeft = this.velocity
+                    // avoid rounding errors and stop if anything is unconsumed
+                    if (abs(delta - consumed) > 0.5f) this.cancelAnimation()
+                } catch (e: Exception) {
+                    this.cancelAnimation()
+                }
             }
             velocityLeft
         } else {


### PR DESCRIPTION
scrollBy in FlingerFlingBehavior was throwing a silent exception when trying to scroll past a container in my app. The try-catch block fixes it by cancelling animation when this happens and finally returning value from performFling function. Normally the animation just never ends. Tested on Android 13 Xiaomi HyperOS 1.0.11.0.

Unfortunately I couldn't reproduce this issue in flinger example app.